### PR TITLE
Add more logger calls

### DIFF
--- a/lib/plausible_proxy/plug.ex
+++ b/lib/plausible_proxy/plug.ex
@@ -91,7 +91,7 @@ defmodule PlausibleProxy.Plug do
       |> halt()
     else
       error ->
-        Logger.error("plausible_proxy failed to POST /api/event, got: #{Exception.message(error)}")
+        Logger.error("plausible_proxy failed to POST /api/event, got: #{inspect(error)}")
 
         conn
         |> send_resp(500, "plausible_proxy failed to POST /api/event")


### PR DESCRIPTION
Fix logging by requiring `Logger` and add some extra logger calls in other clauses that may fail.